### PR TITLE
Update text with bulk download link

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,9 +19,6 @@
             ga('send','pageview');
         </script>
         <script src="https://www.google-analytics.com/analytics.js" async defer></script>
-
-        <meta http-equiv="refresh" content="10;URL='https://www.usa.gov'" /> 
-
     <style>
 
         * {

--- a/index.html
+++ b/index.html
@@ -91,6 +91,9 @@
         <h1>Due to a lapse in government funding all Data.gov websites will be unavailable until further notice.</h1> 
         <p>
             Updates regarding government operating status and resumption of normal operations can be found at <a href="https://www.usa.gov">USA.gov</a></p>
+        <p>
+          <a href="https://filestore.data.gov/gsa/catalog/jsonl/dataset.jsonl.gz">dataset.jsonl.gz</a> (2.6GB) contains a monthly snapshot of the Data.gov catalog metadata in <a href="http://jsonlines.org/">JSONL</a> format.
+        </p>            
         </div>
 
     </body>


### PR DESCRIPTION
@adborden I removed the link to the API info that's currently live since that is a dead link with the rest of the site offline. 